### PR TITLE
一覧画面から商品詳細画面への遷移エラー解消

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -43,7 +43,7 @@
 
         <%# アクションボタン %>
         <div class="product-actions">
-          <% if user_signed_in? && !current_user.admin? %>
+          <% if user_signed_in? && !current_user.is_admin? %>
              <% unless item_sold?(@item) %>
               <%= link_to '購入する', "#", class: "btn btn-purchase" %>
             <% end %>


### PR DESCRIPTION
### what
詳細画面のビュー内で、管理者ユーザーの条件部分の書き直し
モデルに定義していたメソッドを消したため、それに合わせて修正

### why
商品詳細画面遷移時にエラー表示が出ていたため