### PR TITLE
seeds.rbの修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -26,9 +26,9 @@ class Item < ApplicationRecord
   private
 
   def half_width_digits_only_for_price
-    raw = price_before_type_cast
-    return unless raw.present? && raw !~ /\A[0-9]+\z/
-
+    raw = price_before_type_cast.to_s
+    return if raw.blank?
+    return if raw =~ /\A[0-9]+\z/
     errors.add(:price, 'is invalid. Input half-width characters')
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,9 +58,31 @@ Item.create!(
   price: 1000,
   category_id: 2,
   condition_id: 2,
-  # image: ActiveStorage::Blob.create_and_upload!(
-  #   io: File.open(Rails.root.join('app/assets/images/item-sample.png')), # 適切な画像ファイルパスに変更
-  #   filename: 'item-sample.png',
-  #   content_type: 'image/png'
-  # )
+  image: ActiveStorage::Blob.create_and_upload!(
+    io: File.open(Rails.root.join('app/assets/images/item-sample.png')), # 適切な画像ファイルパスに変更
+    filename: 'item-sample.png',
+    content_type: 'image/png'
+  )
 )
+
+unless PointDealType.exists?(type_key: '0001')
+  PointDealType.create!(
+    type_key:    '0001',
+    description: '購入者付与用',
+    is_deposit:  true
+  )
+  puts "PointDealType with type_key '0001' created."
+else
+  puts "PointDealType with type_key '0001' already exists."
+end
+
+unless PointDealType.exists?(type_key: '0002')
+  PointDealType.create!(
+    type_key:    '0002',
+    description: '商品購入時の消費用',
+    is_deposit:  false
+  )
+  puts "PointDealType with type_key '0002' created."
+else
+  puts "PointDealType with type_key '0002' already exists."
+end


### PR DESCRIPTION
### What
PointDealTypeを「rails db:seed」で配れるように。seeds.rbを修正。

### Why
PointDealType配布のため。
Itemが配布できていなかった問題を解決するため。